### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Engino <info@engino.com>
 sentence=Gives easy access to all peripherals of an ERP
 paragraph=
 category=Uncategorized
-url=www.enginorobotics.com
+url=https://www.enginorobotics.com
 architectures=*


### PR DESCRIPTION
The library.properties `url` property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.